### PR TITLE
support merge exist ros template file when compatible mode is set

### DIFF
--- a/rostran/cli/__main__.py
+++ b/rostran/cli/__main__.py
@@ -78,12 +78,12 @@ def transform(
         help="Whether to overwrite existing target file.",
     ),
     extra_files: List[str] = typer.Option(
-            None,
-            show_default=True,
-            help="Add extra files, which supporting the specification of multiple files with fuzzy matching, "
-            "when transforming Terraform to ROS template in compatible mode. "
-            "This option is only available for Terraform template files in compatible mode.",
-        ),
+        None,
+        show_default=True,
+        help="Add extra files, which supporting the specification of multiple files with fuzzy matching, "
+        "when transforming Terraform to ROS template in compatible mode. "
+        "This option is only available for Terraform template files in compatible mode.",
+    ),
 ):
     """
     Transform AWS CloudFormation/Terraform/Excel template to ROS template.
@@ -153,7 +153,8 @@ def transform(
     target_path = os.path.abspath(target_path)
     path = Path(target_path)
     if path.exists() and not force:
-        raise exceptions.TemplateAlreadyExist(path=target_path)
+        if not (compatible and path.is_file()):
+            raise exceptions.TemplateAlreadyExist(path=target_path)
 
     if not path.parent.exists():
         raise exceptions.PathNotExist(path=path.parent)
@@ -170,7 +171,7 @@ def transform(
             from ..providers import CompatibleTerraformTemplate
 
             template = CompatibleTerraformTemplate.initialize(
-                source_path, source_file_format, extra_files
+                source_path, source_file_format, extra_files, target_path, force
             )
         else:
             from ..providers import TerraformTemplate

--- a/rostran/core/exceptions.py
+++ b/rostran/core/exceptions.py
@@ -186,3 +186,7 @@ class CloudFormationTransformNotSupported(RosTranException):
 
 class InvalidTargetPath(RosTranException):
     msg = "Target path {target_path} is invalid, {reason}"
+
+
+class InvalidTargetFile(RosTranException):
+    msg = "Target file {target_file} is invalid, {reason}"

--- a/rostran/core/template.py
+++ b/rostran/core/template.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 from functools import partial
 
 import typer
@@ -85,6 +85,18 @@ class RosTemplate:
         self.rules = rules if rules is not None else Rules()
         self.transform = transform
         self.workspace = workspace
+        self._additional_data = None
+
+
+    @property
+    def additional_data(self):
+        return self._additional_data
+
+    @additional_data.setter
+    def additional_data(self, value):
+        assert isinstance(value, dict), "additional_data must be a dict"
+        self._additional_data = value
+
 
     @classmethod
     def initialize(cls, data: dict):
@@ -167,5 +179,7 @@ class RosTemplate:
             kwargs = {"indent": 2}
 
         data = self.as_dict(format=True)
+        if self.additional_data:
+            data.update(self.additional_data)
         with open(target_path, "w") as f:
             dump(data, f, **kwargs)

--- a/rostran/providers/terraform/c_template.py
+++ b/rostran/providers/terraform/c_template.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from typing import List
@@ -5,22 +6,36 @@ from typing import List
 import typer
 from ruamel.yaml.scalarstring import LiteralScalarString
 
-from rostran.core.exceptions import TemplateFormatNotSupport
+from rostran.core.conditions import Conditions
+from rostran.core.exceptions import TemplateFormatNotSupport, InvalidTargetFile
+from rostran.core.mappings import Mappings
+from rostran.core.metadata import MetaData
+from rostran.core.outputs import Outputs
+from rostran.core.parameters import Parameters
+from rostran.core.rules import Rules
 from rostran.core.template import Template, RosTemplate
 from rostran.core.format import FileFormat
 from rostran.core.workspace import Workspace
+from rostran.providers.ros.yaml_util import yaml
 
 
 class CompatibleTerraformTemplate(Template):
 
     DEFAULT_FILE_PATTERNS = ("*.tf", "*.tftpl", "*.tfvars", "*.metadata", "*.mappings", "*.conditions", "*.rules")
 
+    def __init__(self, source, *args, **kwargs):
+        super().__init__(source, args, kwargs)
+        self.exist_content = kwargs.get("exist_content") or {}
+        self.force_overwrite = kwargs.get("force_overwrite")
+
     @classmethod
     def initialize(
         cls,
         path: str,
         format: FileFormat = FileFormat.Terraform,
-        extra_files: List[str] = None
+        extra_files: List[str] = None,
+        exist_file_path: str = None,
+        force_overwrite: bool = False,
     ):
         if format != FileFormat.Terraform:
             raise TemplateFormatNotSupport(path=path, format=format)
@@ -39,7 +54,32 @@ class CompatibleTerraformTemplate(Template):
                 content = f.read()
             source["main.tf"] = LiteralScalarString(content)
 
-        return cls(source=source)
+        if exist_file_path:
+            exist_content = cls.read_exist_file(exist_file_path)
+        else:
+            exist_content = None
+        return cls(source=source, exist_content=exist_content, force_overwrite=force_overwrite)
+
+    @staticmethod
+    def read_exist_file(exist_file_path):
+        if not os.path.exists(exist_file_path):
+            raise InvalidTargetFile(
+                target_file=exist_file_path, reason="the file is not exists.")
+        if not os.path.isfile(exist_file_path):
+            raise InvalidTargetFile(
+                target_file=exist_file_path, reason="it is not a file.")
+        try:
+            with open(exist_file_path) as f:
+                try:
+                    exist_content = json.load(f)
+                except json.JSONDecodeError:
+                    f.seek(0)
+                    exist_content = yaml.load(f)
+        except Exception as ex:
+            raise InvalidTargetFile(
+                target_file=exist_file_path,
+                reason="the file needs to be in json or yaml format. Error: {}".format(str(ex)))
+        return exist_content
 
     @classmethod
     def get_matched_files(cls, dirpath: str, extra_files: List[str] = None) -> list:
@@ -64,6 +104,25 @@ class CompatibleTerraformTemplate(Template):
         template = RosTemplate()
         template.transform = "Aliyun::Terraform-v1.5"
         template.workspace = Workspace.initialize(self.source)
+        if self.exist_content:
+            template.outputs =  Outputs.initialize(self.exist_content.pop("Outputs", None) or {})
+            template.metadata = MetaData.initialize(self.exist_content.pop("Metadata", None) or {})
+            template.parameters = Parameters.initialize(self.exist_content.pop("Parameters", None) or {})
+            template.rules = Rules.initialize(self.exist_content.pop("Rules", None) or {})
+            template.mappings = Mappings.initialize(self.exist_content.pop("Mappings", None) or {})
+            template.conditions = Conditions.initialize(self.exist_content.pop("Conditions", None) or {})
+            transform = self.exist_content.pop("Transform", None)
+            if transform:
+                template.transform = transform
+            description = self.exist_content.pop("Description", None)
+            if description:
+                template.description = description
+            workspace = self.exist_content.pop("Workspace", None) or {}
+            if workspace and not self.force_overwrite:
+                template.workspace = Workspace.initialize(workspace)
+
+            if self.exist_content:
+                template.additional_data = self.exist_content
 
         typer.secho(
             f"Transform terraform template to ROS template successful.",

--- a/tests/providers/terraform/alicloud/ros-meta.yaml
+++ b/tests/providers/terraform/alicloud/ros-meta.yaml
@@ -1,0 +1,71 @@
+Transform: Aliyun::OpenTofu-v1.8
+Description:
+  zh-cn: 创建VPC
+  en: Create VPC
+Conditions:
+  IsChinaMainland:
+    Fn::Equals:
+    - cn-hangzhou
+    - Ref: Region
+Mappings:
+  RegionMap:
+    ChineseMainland:
+      Ipv6Isp: ChinaMobile
+      Region: cn-hangzhou
+    Overseas:
+      Ipv6Isp: BGP
+      Region: ap-southeast-1
+Parameters:
+  environment:
+    Type: String
+    Description:
+      en: Environment
+      zh-cn: 环境
+    Default: dev
+    AllowedValues:
+    - prod
+    - dev
+  vpc_name:
+    Type: String
+    Description:
+      en: Name of VPC
+      zh-cn: VPC名称
+  subnet_mask:
+    Type: Number
+    Label:
+      en: Subnet mask
+      zh-cn: 子网掩码
+    Description:
+      en: Subnet mask of VSwitch
+      zh-cn: 交换机子网掩码
+    Default: 21
+    MinValue: 13
+    MaxValue: 31
+Outputs:
+  vpc_id:
+    Description:
+      en: VPC ID
+      zh-cn: 专有网络ID
+    Value:
+      Ref: vpc
+Rules:
+  PublicNet:
+    RuleCondition:
+      Fn::Equals:
+      - Ref: environment
+      - prod
+    Assertions:
+    - Assert:
+        Fn::Equals:
+        - Ref: InternetMaxBandwidthOut
+        - 0
+      AssertDescription: ECS instance should be intranet when the environment is prod.
+Metadata:
+  ALIYUN::ROS::Interface:
+    ParameterGroups:
+    - Parameters:
+      - environment
+      - vpc_name
+      - subnet_mask
+AdditionalData:
+  Key: Value

--- a/tests/providers/terraform/test_compatible_terraform.py
+++ b/tests/providers/terraform/test_compatible_terraform.py
@@ -64,3 +64,20 @@ def test_template_with_extra_files():
     assert workspace.get("main.tf")
     assert workspace.get(".metadata")
     assert workspace.get("charts/example/Chart.yaml")
+
+def test_template_with_target_path():
+    target_path = os.path.join(TERRAFORM_ALICLOUD_DIR, "ros-meta.yaml")
+    template = CompatibleTerraformTemplate.initialize(
+        TERRAFORM_ALICLOUD_DIR, exist_file_path=target_path)
+    ros_template = template.transform()
+    d = ros_template.as_dict(format=True)
+
+    assert "Workspace" in d
+    assert "Parameters" in d
+    assert "Mappings" in d
+    assert "Conditions" in d
+    assert "Outputs" in d
+    assert "Metadata" in d
+    assert "Rules" in d
+    assert "Description" in d
+    assert d["Transform"] == "Aliyun::OpenTofu-v1.8"


### PR DESCRIPTION
When converting Terraform to ROS templates using compatibility mode, the template structure information in the specified file is written into the generated ROS template.