### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/aliyun/alibabacloud-ros-tool-transformer/security/code-scanning/1](https://github.com/aliyun/alibabacloud-ros-tool-transformer/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/test.yml` at the workflow root (right after `on` is a clean location).  
For this workflow, the least-privilege setting is:

- `contents: read`

This preserves existing functionality:
- `actions/checkout` needs repository read access.
- setup/install/test steps do not require write scopes.

No imports, methods, or extra definitions are needed—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
