### PR TITLE
Add browser locale redirect for website

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
   projectName: 'alibabacloud-ros-tool-transformer',
 
   onBrokenLinks: 'throw',
+  clientModules: ['./src/clientModules/localeRedirect.mjs'],
 
   i18n: {
     defaultLocale: 'en',

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "test": "node --test src/clientModules/*.test.mjs",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"

--- a/website/src/clientModules/localeRedirect.mjs
+++ b/website/src/clientModules/localeRedirect.mjs
@@ -1,0 +1,197 @@
+const DEFAULT_LOCALE = 'en';
+const SUPPORTED_LOCALES = ['en', 'zh-cn'];
+const BASE_URL = '/alibabacloud-ros-tool-transformer/';
+const REDIRECT_SESSION_KEY = 'ros-tool-transformer.localeRedirected';
+
+function normalizeLanguage(language) {
+  return typeof language === 'string'
+    ? language.trim().toLowerCase().replace(/_/g, '-')
+    : '';
+}
+
+function normalizeBaseUrl(baseUrl) {
+  const withLeadingSlash = baseUrl.startsWith('/') ? baseUrl : `/${baseUrl}`;
+  return withLeadingSlash.endsWith('/')
+    ? withLeadingSlash
+    : `${withLeadingSlash}/`;
+}
+
+function getPathWithinBase(pathname, baseUrl) {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+
+  if (normalizedBaseUrl === '/') {
+    return pathname.startsWith('/') ? pathname.slice(1) : null;
+  }
+
+  const baseWithoutTrailingSlash = normalizedBaseUrl.slice(0, -1);
+  if (pathname === baseWithoutTrailingSlash || pathname === normalizedBaseUrl) {
+    return '';
+  }
+
+  if (!pathname.startsWith(normalizedBaseUrl)) {
+    return null;
+  }
+
+  return pathname.slice(normalizedBaseUrl.length);
+}
+
+function getSupportedLocaleMap(supportedLocales) {
+  return supportedLocales.map((locale) => ({
+    locale,
+    normalized: normalizeLanguage(locale),
+  }));
+}
+
+export function getPreferredLocale(
+  languages,
+  {supportedLocales = SUPPORTED_LOCALES, defaultLocale = DEFAULT_LOCALE} = {},
+) {
+  const supportedLocaleMap = getSupportedLocaleMap(supportedLocales);
+
+  for (const language of languages ?? []) {
+    const normalizedLanguage = normalizeLanguage(language);
+    if (!normalizedLanguage) {
+      continue;
+    }
+
+    const directMatch = supportedLocaleMap.find(
+      ({normalized}) => normalized === normalizedLanguage,
+    );
+    if (directMatch) {
+      return directMatch.locale;
+    }
+
+    const primaryLanguage = normalizedLanguage.split('-')[0];
+    const primaryMatch = supportedLocaleMap.find(
+      ({normalized}) =>
+        normalized === primaryLanguage ||
+        normalized.startsWith(`${primaryLanguage}-`),
+    );
+    if (primaryMatch) {
+      return primaryMatch.locale;
+    }
+  }
+
+  return defaultLocale;
+}
+
+export function isLocalizedPath(
+  pathname,
+  {
+    baseUrl = BASE_URL,
+    supportedLocales = SUPPORTED_LOCALES,
+    defaultLocale = DEFAULT_LOCALE,
+  } = {},
+) {
+  const pathWithinBase = getPathWithinBase(pathname, baseUrl);
+  if (pathWithinBase === null) {
+    return false;
+  }
+
+  const [firstSegment] = pathWithinBase.split('/');
+  const localizedPrefixes = supportedLocales
+    .filter((locale) => locale !== defaultLocale)
+    .map(normalizeLanguage);
+  return localizedPrefixes.includes(normalizeLanguage(firstSegment));
+}
+
+export function getLocaleRedirectUrl({
+  baseUrl = BASE_URL,
+  languages,
+  pathname,
+  search = '',
+  hash = '',
+  supportedLocales = SUPPORTED_LOCALES,
+  defaultLocale = DEFAULT_LOCALE,
+}) {
+  const pathWithinBase = getPathWithinBase(pathname, baseUrl);
+  if (
+    pathWithinBase === null ||
+    isLocalizedPath(pathname, {baseUrl, supportedLocales, defaultLocale})
+  ) {
+    return null;
+  }
+
+  const preferredLocale = getPreferredLocale(languages, {
+    supportedLocales,
+    defaultLocale,
+  });
+  if (preferredLocale === defaultLocale) {
+    return null;
+  }
+
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const localizedPath = pathWithinBase
+    ? `${preferredLocale}/${pathWithinBase}`
+    : `${preferredLocale}/`;
+  const normalizedSearch =
+    search && !search.startsWith('?') ? `?${search}` : search;
+  const normalizedHash = hash && !hash.startsWith('#') ? `#${hash}` : hash;
+
+  return `${normalizedBaseUrl}${localizedPath}${normalizedSearch}${normalizedHash}`;
+}
+
+function getBrowserLanguages(browserWindow) {
+  const languages = browserWindow.navigator?.languages;
+  if (Array.isArray(languages) && languages.length > 0) {
+    return languages;
+  }
+
+  return browserWindow.navigator?.language ? [browserWindow.navigator.language] : [];
+}
+
+function getSessionStorage(browserWindow) {
+  try {
+    return browserWindow.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function hasRedirected(storage) {
+  try {
+    return storage?.getItem(REDIRECT_SESSION_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function rememberRedirect(storage) {
+  try {
+    storage?.setItem(REDIRECT_SESSION_KEY, 'true');
+  } catch {
+    // Ignore storage failures in privacy-restricted browser contexts.
+  }
+}
+
+export function runBrowserLocaleRedirect(browserWindow = globalThis.window) {
+  if (!browserWindow?.location) {
+    return;
+  }
+
+  const storage = getSessionStorage(browserWindow);
+  const {pathname, search, hash} = browserWindow.location;
+
+  if (isLocalizedPath(pathname)) {
+    rememberRedirect(storage);
+    return;
+  }
+
+  if (hasRedirected(storage)) {
+    return;
+  }
+
+  const redirectUrl = getLocaleRedirectUrl({
+    languages: getBrowserLanguages(browserWindow),
+    pathname,
+    search,
+    hash,
+  });
+
+  if (redirectUrl) {
+    rememberRedirect(storage);
+    browserWindow.location.replace(redirectUrl);
+  }
+}
+
+runBrowserLocaleRedirect();

--- a/website/src/clientModules/localeRedirect.test.mjs
+++ b/website/src/clientModules/localeRedirect.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getPreferredLocale,
+  getLocaleRedirectUrl,
+} from './localeRedirect.mjs';
+
+const baseUrl = '/alibabacloud-ros-tool-transformer/';
+
+test('uses the zh-cn locale for Chinese browser language variants', () => {
+  assert.equal(getPreferredLocale(['zh-CN', 'en-US']), 'zh-cn');
+  assert.equal(getPreferredLocale(['zh-Hans-CN', 'en-US']), 'zh-cn');
+  assert.equal(getPreferredLocale(['zh']), 'zh-cn');
+});
+
+test('falls back to the default locale for unsupported browser languages', () => {
+  assert.equal(getPreferredLocale(['fr-FR', 'de-DE']), 'en');
+  assert.equal(getPreferredLocale([]), 'en');
+});
+
+test('redirects default-locale pages to the preferred localized page', () => {
+  assert.equal(
+    getLocaleRedirectUrl({
+      baseUrl,
+      languages: ['zh-CN'],
+      pathname: '/alibabacloud-ros-tool-transformer/usage',
+      search: '?from=docs',
+      hash: '#examples',
+    }),
+    '/alibabacloud-ros-tool-transformer/zh-cn/usage?from=docs#examples',
+  );
+});
+
+test('redirects the site root to the preferred localized root', () => {
+  assert.equal(
+    getLocaleRedirectUrl({
+      baseUrl,
+      languages: ['zh-CN'],
+      pathname: '/alibabacloud-ros-tool-transformer/',
+    }),
+    '/alibabacloud-ros-tool-transformer/zh-cn/',
+  );
+});
+
+test('does not redirect already-localized pages', () => {
+  assert.equal(
+    getLocaleRedirectUrl({
+      baseUrl,
+      languages: ['zh-CN'],
+      pathname: '/alibabacloud-ros-tool-transformer/zh-cn/usage',
+    }),
+    null,
+  );
+});
+
+test('does not redirect non-Chinese browsers or URLs outside the site base', () => {
+  assert.equal(
+    getLocaleRedirectUrl({
+      baseUrl,
+      languages: ['en-US'],
+      pathname: '/alibabacloud-ros-tool-transformer/usage',
+    }),
+    null,
+  );
+  assert.equal(
+    getLocaleRedirectUrl({
+      baseUrl,
+      languages: ['zh-CN'],
+      pathname: '/other-site/usage',
+    }),
+    null,
+  );
+});


### PR DESCRIPTION
## Summary
- add a Docusaurus client module that redirects first-time default-locale visits to zh-cn when the browser prefers Chinese
- preserve path, query, and hash during locale redirect
- add Node test coverage for locale matching and redirect URL behavior

## Verification
- /Users/prodesire/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test src/clientModules/*.test.mjs
- /Users/prodesire/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/typescript/bin/tsc --noEmit
- /Users/prodesire/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/@docusaurus/core/bin/docusaurus.mjs build
- git diff --check
- Chrome DevTools E2E: zh-CN redirects to /zh-cn/usage?from=docs#examples; en-US stays on /usage?from=docs#examples